### PR TITLE
Tweak - the IP capturing method for guest user.

### DIFF
--- a/src/Guest.php
+++ b/src/Guest.php
@@ -15,6 +15,31 @@ class Guest
 
     public function __construct(Request $request)
     {
-            $this->user_id = $request->ip();
+        $this->user_id = $this->getClientIPAddress($request);
+    }
+
+    private function getClientIPAddress($request)
+    {
+        //For Cloudflare
+        if (!empty($request->server('HTTP_CF_CONNECTING_IP')))
+        {
+            $ipAddress = $request->server('HTTP_CF_CONNECTING_IP');
+        }
+        //For share internet IP
+        elseif (!empty($request->server('HTTP_CLIENT_IP')))
+        {
+            $ipAddress = $request->server('HTTP_CLIENT_IP');
+        }
+        //For Google App Engine and other proxy
+        elseif (!empty($request->server('HTTP_X_FORWARDED_FOR')))
+        {
+            $temp      = $request->server('HTTP_X_FORWARDED_FOR');
+            $ipAddress = trim(explode(',', $temp)[0]);
+        }
+        else
+        {
+            $ipAddress = $request->ip();
+        }
+        return $ipAddress;
     }
 }


### PR DESCRIPTION
If a site is using Cloudflare as a DNS manager and if the request are peroxide via Cloudflare then it set's a different header HTTP_CF_CONNECTING_IP which has the visitor IP address. So this commit will solve the issue #111